### PR TITLE
Add support for per-path configuration

### DIFF
--- a/lib/init.coffee
+++ b/lib/init.coffee
@@ -9,8 +9,8 @@ checkedAppend = (parameters, opt, args) ->
     parameters.push opt
     parameters.push(args...)
 
-makeParameters = (globals, ignore) ->
-  parameters = ['-', '--no-color', '--codes', '--ranges']
+makeParameters = (globals, ignore, file) ->
+  parameters = ['-', '--no-color', '--codes', '--ranges', "--filename=" + file]
   checkedAppend parameters, '--globals', globals
   checkedAppend parameters, '--ignore', ignore
   parameters
@@ -54,7 +54,7 @@ module.exports =
         globals = atom.config.get 'linter-luacheck.globals'
         ignore = atom.config.get 'linter-luacheck.ignore'
 
-        return helpers.exec(executable, makeParameters(globals, ignore),
+        return helpers.exec(executable, makeParameters(globals, ignore, file),
           {
             cwd: path.dirname file
             stdin: editor.getText()


### PR DESCRIPTION
I'm not really sure if I should make a pull request to [xpol/linter-luacheck](https://github.com/xpol/linter-luacheck) or [AtomLinter/linter-luacheck](https://github.com/AtomLinter/linter-luacheck), and there were no instructions... But hopefully it will get merged anyway.

Luacheck has support for per-file and per-path configuration:
http://luacheck.readthedocs.org/en/latest/config.html#per-file-and-per-path-overrides

This adds support for these in linter-luacheck as well, by explicitly specifying the file name for Luacheck, so that it can correctly check the configuration file.
